### PR TITLE
handle newlines in SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,5 @@ Happy to accept PRs to generate ORM defs from `create table` stmts (or vice vers
 pip install pytest
 pytest # in repo root
 ```
+
+If you want to pitch in on the project, there are a bunch of `@pytest.mark.skip` tests that need to be filled in (most require feature development to get them passing).

--- a/automig/lib/wrappers.py
+++ b/automig/lib/wrappers.py
@@ -23,6 +23,13 @@ class WrappedStatement:
     "return table name string"
     return self.decl().get_name()
 
+def iswhitespace(token):
+  # todo: learn more about this -- Token.Text.Whitespace.Newline, should I be testing ttype[2]?
+  return isinstance(token, sqlparse.sql.Token) \
+    and token.ttype \
+    and token.ttype[-1] == 'Whitespace'
+    # and (token.ttype[-1] == 'Whitespace' or token.ttype[-1] == 'Newline')
+
 def split_pun(tokens):
   """Takes a list of tokens and other stuff.
   Returns contiguous blocks of non-punctuation, i.e. list of lists.
@@ -34,7 +41,7 @@ def split_pun(tokens):
     if isinstance(tok, sqlparse.sql.Token) and tok.ttype and tok.ttype[0] == 'Punctuation':
       if groups[-1]: # i.e. if there's a non-empty group
         groups.append([])
-    elif isinstance(tok, sqlparse.sql.Token) and tok.ttype and tok.ttype[-1] == 'Whitespace':
+    elif iswhitespace(tok):
       pass
     elif isinstance(tok, sqlparse.sql.IdentifierList):
       # this is insane

--- a/automig/lib/wrappers.py
+++ b/automig/lib/wrappers.py
@@ -27,8 +27,7 @@ def iswhitespace(token):
   # todo: learn more about this -- Token.Text.Whitespace.Newline, should I be testing ttype[2]?
   return isinstance(token, sqlparse.sql.Token) \
     and token.ttype \
-    and token.ttype[-1] == 'Whitespace'
-    # and (token.ttype[-1] == 'Whitespace' or token.ttype[-1] == 'Newline')
+    and (token.ttype[-1] == 'Whitespace' or token.ttype[-1] == 'Newline')
 
 def split_pun(tokens):
   """Takes a list of tokens and other stuff.

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -44,3 +44,12 @@ def test_add_index():
 @pytest.mark.skip
 def test_all_caps_keywords():
   raise NotImplementedError
+
+NEWLINE = [
+  'create table whatever (\n  a int\n);',
+  'create table whatever (\n  a int,\n  b int\n);'
+]
+
+def test_newline():
+  # this isn't asserting anything -- checking for a bug which caused a crash
+  diffing.diff(*map(sqlparse.parse, NEWLINE))


### PR DESCRIPTION
## Problem
* Newlines in SQL statements crashed the parser
* This fixes #2 
## Solution
* Factor out `iswhitespace`, add check for `Whitespace.Newline` tokens
* Check this in tests
## Follow-on work
* Read sqlparse docs, comprehend `token.ttype` and do a more reliable check