### PR TITLE
basic drop & alter column support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ insert into automigrate_meta (sha) values ('b5b40ce718ea7241fee8d0a3826f244d21bf
 ## What does & doesn't work
 
 * [x] Adding tables, indexes and columns should mostly work
+* [x] drop column works
 * [ ] modifying primary keys doesn't work
 * [ ] modifying column types doesn't work (even something inoccuous like a default)
 * [x] For diffs that are erroring, you can override with a [.manualmig.yml file](./.manualmig.yml)

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ insert into automigrate_meta (sha) values ('b5b40ce718ea7241fee8d0a3826f244d21bf
 
 * [x] Adding tables, indexes and columns should mostly work
 * [x] drop column works
+* [x] modifying columns partially works, supports changes to types, defaults, nullable. Read the `diff_column()` function for up-to-date information and file bugs for specific holes.
 * [ ] modifying primary keys doesn't work
-* [ ] modifying column types doesn't work (even something inoccuous like a default)
 * [x] For diffs that are erroring, you can override with a [.manualmig.yml file](./.manualmig.yml)
 * [ ] Be careful with using unescaped keywords as names (i.e. a table named table) -- you'll likely confuse the parser even where your sql engine allows it
 * [ ] This hasn't been tested on a wide range of syntax (i.e. arrays / json)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ insert into automigrate_meta (sha) values ('b5b40ce718ea7241fee8d0a3826f244d21bf
     - todo: find a way to automatically detect & recover from rebases
     - todo: provide an `--opaque` argument that doesn't try to create granular changes for each commit in the history
 * [ ] include `from_sha` in `automigrate_meta` table for audit trail
+* [ ] I think you have to explicitly name your indexes (don't rely on the auto-generated DB ones)
 
 ## Comparison vs other tools
 

--- a/automig/__main__.py
+++ b/automig/__main__.py
@@ -48,6 +48,7 @@ def main():
     changes = ref_diff.ref_range_diff(git.Repo(search_parent_directories=True), *rev_tuple, args.glob)
     errors = ref_diff.extract_errors(changes)
     if errors:
+      # todo: this is wrong. manual_mig should override whether or not there are errors
       remaining = ref_diff.try_repair_errors(errors, manual_mig, changes)
       if remaining:
         raise ValueError('errors not overridden in .manualmig.yml', remaining)

--- a/automig/lib/diffing.py
+++ b/automig/lib/diffing.py
@@ -20,6 +20,30 @@ def group_by_table(stmts):
 class UnsupportedChange(Exception):
   "returned in place of a migration string when there's an error"
 
+def diff_column(table, left, right):
+  "return list of stmts to alter column, or UnsupportedChange if we're confused"
+  if not left.success or not right.success:
+    # todo: add details (column name and rendered old/new)
+    return [UnsupportedChange("the column parser failed on an alter")]
+  assert left.name == right.name
+  ret = []
+  prefix = f"alter table {table} alter column {left.name}"
+  if left.type != right.type:
+    ret.append(f"{prefix} type {right.type};")
+  if left.default != right.default:
+    if right.default is None:
+      ret.append(UnsupportedChange("can't unset default, file a bug and workaround by setting `default null` for now"))
+    else:
+      ret.append(f"{prefix} set default {right.default};")
+  if left.unique != right.unique:
+    ret.append(UnsupportedChange("can't modify uniqueness, file a bug"))
+  if left.not_null != right.not_null:
+    # note: I think the possible values here are (None | True), shouldn't ever be False
+    # todo: refactor this to `null` and include null / not_null as sources
+    # todo: this is assuming that 'not specified' is nullable -- link to DB docs supporting this and figure out the pkey case
+    ret.append(f"{prefix} {'set' if right.not_null else 'drop'} not null;")
+  return ret
+
 def diff_stmt(left, right):
   "diff two WrappedStmt with same unique key. return list of statements to run."
   assert left.unique == right.unique
@@ -37,10 +61,8 @@ def diff_stmt(left, right):
       if k in left_cols and left_cols[k] != right_cols[k]
     }
     if changed:
-      for a, b in changed.values(): print('toks', a.parse(), b.parse())
-      raise NotImplementedError("changed", changed)
-      detail = {k: (a.render(), b.render()) for k, (a, b) in changed.items()}
-      return [UnsupportedChange("we don't know how to change columns", detail)]
+      for left_col, right_col in changed.values():
+        changes.extend(diff_column(table, left_col.parse(), right_col.parse()))
     for k in left_cols:
       if k not in right_cols:
         changes.append(f'alter table {table} drop column {k};')

--- a/automig/lib/diffing.py
+++ b/automig/lib/diffing.py
@@ -37,6 +37,8 @@ def diff_stmt(left, right):
       if k in left_cols and left_cols[k] != right_cols[k]
     }
     if changed:
+      for a, b in changed.values(): print('toks', a.parse(), b.parse())
+      raise NotImplementedError("changed", changed)
       detail = {k: (a.render(), b.render()) for k, (a, b) in changed.items()}
       return [UnsupportedChange("we don't know how to change columns", detail)]
     for k in left_cols:

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -25,13 +25,21 @@ def test_add_column():
   assert delta == {'t1': ['alter table t1 add column b int;']}
 
 MODIFY_COLUMN = [
-  'create table t1 (a int primary key, b int default 10, c text, d varchar(12), e text);',
+  'create table t1 (a int primary key, b int default 10, c text, d varchar(12));',
   # this is modifying a default, setting not nullable, and changing a varchar size
-  'create table t1 (a int primary key, b int default 20, c text not null, d varchar(24), e text unique);',
+  'create table t1 (a int primary key, b int default 20, c text not null, d varchar(24));',
 ]
 
 def test_modify_column():
-  print(diffing.diff(*map(sqlparse.parse, MODIFY_COLUMN)))
+  assert diffing.diff(*map(sqlparse.parse, MODIFY_COLUMN)) == {'t1': [
+    'alter table t1 alter column b set default 20;',
+    'alter table t1 alter column c set not null;',
+    'alter table t1 alter column d type varchar(24);',
+  ]}
+
+@pytest.mark.skip
+def test_diff_column():
+  "directly test diff_column cases"
   raise NotImplementedError
 
 DROP_COLUMN = [

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -24,8 +24,23 @@ def test_add_column():
   delta = diffing.diff(*map(sqlparse.parse, ADD_COLUMN))
   assert delta == {'t1': ['alter table t1 add column b int;']}
 
-@pytest.mark.skip
+MODIFY_COLUMN = [
+  'create table t1 (a int primary key, b int default 10, c text, d varchar(12));',
+  # this is modifying a default, setting not nullable, and changing a varchar size
+  'create table t1 (a int primary key, b int default 20, c text not null, d varchar(24));',
+]
+
 def test_modify_column():
+  print(diffing.diff(*map(sqlparse.parse, MODIFY_COLUMN)))
+  raise NotImplementedError
+
+DROP_COLUMN = [
+  'create table t1 (a int primary key, b int, c int);',
+  'create table t1 (a int primary key, c int);',
+]
+
+def test_drop_column():
+  print(diffing.diff(*map(sqlparse.parse, DROP_COLUMN)))
   raise NotImplementedError
 
 @pytest.mark.skip

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -40,8 +40,8 @@ DROP_COLUMN = [
 ]
 
 def test_drop_column():
-  print(diffing.diff(*map(sqlparse.parse, DROP_COLUMN)))
-  raise NotImplementedError
+  delta = diffing.diff(*map(sqlparse.parse, DROP_COLUMN))
+  assert delta == {'t1': ['alter table t1 drop column b;']}
 
 @pytest.mark.skip
 def test_modify_key():

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -25,9 +25,9 @@ def test_add_column():
   assert delta == {'t1': ['alter table t1 add column b int;']}
 
 MODIFY_COLUMN = [
-  'create table t1 (a int primary key, b int default 10, c text, d varchar(12));',
+  'create table t1 (a int primary key, b int default 10, c text, d varchar(12), e text);',
   # this is modifying a default, setting not nullable, and changing a varchar size
-  'create table t1 (a int primary key, b int default 20, c text not null, d varchar(24));',
+  'create table t1 (a int primary key, b int default 20, c text not null, d varchar(24), e text unique);',
 ]
 
 def test_modify_column():

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -42,6 +42,11 @@ def test_diff_column():
   "directly test diff_column cases"
   raise NotImplementedError
 
+@pytest.mark.skip
+def test_column_parser():
+  "directly test wrappers.Column.parse() cases"
+  raise NotImplementedError
+
 DROP_COLUMN = [
   'create table t1 (a int primary key, b int, c int);',
   'create table t1 (a int primary key, c int);',

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -39,7 +39,7 @@ def test_add_multi_commit():
 
 MOD_COLUMN = [
   'create table t1 (a int primary key, b int);',
-  'create table t1 (a int primary key, b int default 10);',
+  'create table t1 (a int primary key, b int unique);',
 ]
 
 def test_error_bubbling():


### PR DESCRIPTION
## Feature changes
* support dropping columns
* support common `alter column` cases: some nullability changes, changed type, defaults
## Code changes
* `ParsedColumn` and `wrappers.Column.parse()` to turn sqlparse tokens into diffable column attributes
* `diff_column` function to generate `alter table` statements from old & new `ParsedColumn` objects