### PR TITLE
primary key fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ insert into automigrate_meta (fromsha, sha, automig_version, opaque) values ('9d
 
 * [ ] [0.2.0] integration test with mysql and postgres
 * [ ] [0.2.0] take more than one glob
+* [ ] [0.2.0] support 'create extension'
+* [ ] [0.2.0] support enums
 
 ## Comparison vs other tools
 

--- a/automig/lib/wrappers.py
+++ b/automig/lib/wrappers.py
@@ -54,16 +54,19 @@ def split_pun(tokens):
   return groups
 
 class ParsedColumn:
-  __slots__ = ('success', 'name', 'type', 'default', 'unique', 'not_null')
-  def __init__(self, success, name=None, type=None, default=None, unique=None, not_null=None):
+  # todo: py 3.7 dataclass
+  __slots__ = ('success', 'name', 'type', 'default', 'unique', 'not_null', 'pkey')
+  def __init__(self, success, name=None, type=None, default=None, unique=None, not_null=None, pkey=False):
     self.success = success
     self.name = name
     self.type = type
     self.default = default
     self.unique = unique
     self.not_null = not_null
+    self.pkey = pkey
 
   def __eq__(self, other):
+    # todo: py 3.7 dataclass provides this automatically
     if not isinstance(other, self.__class__):
       return False
     return tuple(map(lambda slot: getattr(self, slot), self.__slots__)) == \
@@ -110,9 +113,24 @@ class Column:
         elif tokens[0].normalized.lower() == 'unique':
           _, *tokens = tokens
           success.unique = True
+        elif tokens[0].normalized.lower() == 'primary':
+          _, key, *tokens = tokens
+          assert key.normalized.lower() == 'key'
+          success.pkey = True
       else:
         return ParsedColumn(False)
     return success
+
+def split_pun_paren(decl):
+  """return things inside parenthesis, split by punctuation.
+  decl is a 'function expression' i.e. a piece of a create table
+  """
+  paren = next(
+    expr for expr in decl
+    if isinstance(expr, sqlparse.sql.Parenthesis)
+  )
+  return split_pun(paren)
+
 
 class CreateTable(WrappedStatement):
   def __init__(self, stmt):
@@ -120,13 +138,8 @@ class CreateTable(WrappedStatement):
     super().__init__(stmt)
 
   def groups(self):
-    "helper for columns() and pkey_fields(). returns tokens after first paren grouped by punctuation split."
-    decl = self.decl()
-    paren = next(
-      expr for expr in self.decl()
-      if isinstance(expr, sqlparse.sql.Parenthesis)
-    )
-    return split_pun(paren)
+    "helper for columns() and pkey_fields(). returns tokens inside the first paren, grouped by punctuation split."
+    return split_pun_paren(self.decl())
 
   def columns(self):
     return [
@@ -135,6 +148,16 @@ class CreateTable(WrappedStatement):
       # note: this guard blocks 'primary key (a,b)' kind of thing
       if isinstance(group[0], sqlparse.sql.Identifier)
     ]
+
+  def pkey_fields(self):
+    "return list of column names that are in primary key"
+    for group in self.groups():
+      if isinstance(group[0], sqlparse.sql.Token) and group[0].ttype and group[0].ttype[0] == 'Keyword':
+        idents = [ident for ident, in split_pun_paren(group)]
+        assert all(isinstance(ident, sqlparse.sql.Identifier) for ident in idents)
+        return [str(ident) for ident in idents]
+    else:
+      return [col.name for col in self.columns() if col.parse().pkey]
 
   @property
   def unique(self):

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -59,6 +59,8 @@ def test_column_parser():
     assert parse_column(type_ + ' default 20') == wrappers.ParsedColumn(True, 'x', type_, default='20')
     assert parse_column(type_ + " default 'hello'") == wrappers.ParsedColumn(True, 'x', type_, default="'hello'")
     assert parse_column(type_ + ' not null unique default 20') == wrappers.ParsedColumn(True, 'x', type_, not_null=True, unique=True, default='20')
+  # make sure it doesn't treat 'primary key' as a column
+  assert [col.name for col in wrappers.wrap(sqlparse.parse("create table t1 (a int, b int, primary key (a,b))")[0]).columns()] == ['a', 'b']
 
 DROP_COLUMN = [
   'create table t1 (a int primary key, b int, c int);',

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -62,6 +62,10 @@ def test_column_parser():
   # make sure it doesn't treat 'primary key' as a column
   assert [col.name for col in wrappers.wrap(sqlparse.parse("create table t1 (a int, b int, primary key (a,b))")[0]).columns()] == ['a', 'b']
 
+def test_pkey_fields():
+  assert ['a'] == wrappers.wrap(sqlparse.parse("create table t1 (a int primary key, b int)")[0]).pkey_fields()
+  assert ['a', 'b'] == wrappers.wrap(sqlparse.parse("create table t1 (a int, b int, primary key (a,b))")[0]).pkey_fields()
+
 DROP_COLUMN = [
   'create table t1 (a int primary key, b int, c int);',
   'create table t1 (a int primary key, c int);',


### PR DESCRIPTION
## Bug
* can't diff composite primary keys, or diff any table with a separately declared pkey
* for example: `create table (a int, b int, primary key (a, b))`
## Changes
* `pkey_fields()` meth on `CreateTable` class and various refactoring to support this
* (incidental) use `ParsedColumn` in `sa_harness`