### PR TITLE
support uppercase, test both cases

### DIFF
--- a/automig/lib/sa_harness.py
+++ b/automig/lib/sa_harness.py
@@ -59,7 +59,7 @@ def transform(table_stmts, delim=',\n  '):
           name, type_, dets = column_args(col, pkey_fields)
           cols[name, type_] = dets
       elif isinstance(stmt, wrappers.CreateIndex):
-        paren = stmt.decl()[-1]
+        paren = stmt.paren()
         assert isinstance(paren, sqlparse.sql.Parenthesis)
         index_cols = ['%s_table.c.%s' % (stmt.table, ident) for ident, in wrappers.split_pun(paren)]
         indexes.append(f"{stmt.index_name}_index = sa.Index('{stmt.index_name}', {', '.join(index_cols)})")

--- a/automig/lib/wrappers.py
+++ b/automig/lib/wrappers.py
@@ -29,20 +29,15 @@ class WrappedStatement:
     first_fn = next_instance(self.stmt, sqlparse.sql.Function, True)
     return next_instance(first_fn or self.stmt, sqlparse.sql.Parenthesis)
 
-  def decl(self):
-    "helper to get the function element, i.e. the table declaration"
-    # careful: sqlparse is inconsistent for ucase / lcase, hence the two cases here
-    print('self.stmt', list(self.stmt))
-    first_fn = next((expr for expr in self.stmt if isinstance(expr, sqlparse.sql.Function)), None)
-    if first_fn is not None:
-      return first_fn
-    else:
-      raise MiscBadParse("Can't parse table declaration. Did you name a table with a sql keyword?", list(self.stmt))
-
   @property
   def table(self):
     "return table name string"
-    return self.decl().get_name()
+    # careful: sqlparse is inconsistent for ucase / lcase, hence the two cases here
+    first_fn = next_instance(self.stmt, sqlparse.sql.Function, True)
+    if first_fn is not None:
+      return first_fn.get_name()
+    else:
+      return next_instance(self.stmt, sqlparse.sql.Identifier).get_name()
 
 def iswhitespace(token):
   "for splitting purposes, is this ignorable? includes whitespace & comments"

--- a/automig/lib/wrappers.py
+++ b/automig/lib/wrappers.py
@@ -173,8 +173,8 @@ class CreateTable(WrappedStatement):
     return ('create', self.table)
 
   def tail(self):
-    "non-space tokens after column parens"
-    paren_index = next((i for i, expr in enumerate(self.stmt) if isinstance(expr, sqlparse.sql.Function)), None)
+    "non-space tokens after column parens. this will be slightly different in lcase/ucase cases"
+    paren_index = next((i for i, expr in enumerate(self.stmt) if isinstance(expr, (sqlparse.sql.Function, sqlparse.sql.Parenthesis))), None)
     if paren_index is None:
       return None
     tail = self.stmt[paren_index + 1:]

--- a/automig/lib/wrappers.py
+++ b/automig/lib/wrappers.py
@@ -4,6 +4,14 @@ import sqlparse
 
 class MiscBadParse(Exception): pass
 
+def next_instance(iterable, types, default_none=False):
+  "get expression with matching type"
+  iter2 = (expr for expr in iterable if isinstance(expr, types))
+  if default_none:
+    return next(iter2, None)
+  else:
+    return next(iter2)
+
 class WrappedStatement:
   "base class"
   __slots__ = ('stmt',)
@@ -16,12 +24,20 @@ class WrappedStatement:
     "yes this is the way adults compare parse trees"
     return str(self.stmt).strip() == str(other.stmt).strip()
 
+  def paren(self):
+    "return first parenthesis element, handling ucase / lcase cases"
+    first_fn = next_instance(self.stmt, sqlparse.sql.Function, True)
+    return next_instance(first_fn or self.stmt, sqlparse.sql.Parenthesis)
+
   def decl(self):
     "helper to get the function element, i.e. the table declaration"
-    ret = next((expr for expr in self.stmt if isinstance(expr, sqlparse.sql.Function)), None)
-    if ret is None:
+    # careful: sqlparse is inconsistent for ucase / lcase, hence the two cases here
+    print('self.stmt', list(self.stmt))
+    first_fn = next((expr for expr in self.stmt if isinstance(expr, sqlparse.sql.Function)), None)
+    if first_fn is not None:
+      return first_fn
+    else:
       raise MiscBadParse("Can't parse table declaration. Did you name a table with a sql keyword?", list(self.stmt))
-    return ret
 
   @property
   def table(self):
@@ -128,17 +144,6 @@ class Column:
         return ParsedColumn(False)
     return success
 
-def split_pun_paren(decl):
-  """return things inside parenthesis, split by punctuation.
-  decl is a 'function expression' i.e. a piece of a create table
-  """
-  paren = next(
-    expr for expr in decl
-    if isinstance(expr, sqlparse.sql.Parenthesis)
-  )
-  return split_pun(paren)
-
-
 class CreateTable(WrappedStatement):
   def __init__(self, stmt):
     assert stmt.get_type() == 'CREATE'
@@ -146,7 +151,7 @@ class CreateTable(WrappedStatement):
 
   def groups(self):
     "helper for columns() and pkey_fields(). returns tokens inside the first paren, grouped by punctuation split."
-    return split_pun_paren(self.decl())
+    return split_pun(self.paren())
 
   def columns(self):
     return [
@@ -160,7 +165,7 @@ class CreateTable(WrappedStatement):
     "return list of column names that are in primary key"
     for group in self.groups():
       if isinstance(group[0], sqlparse.sql.Token) and group[0].ttype and group[0].ttype[0] == 'Keyword' and group[0].value.lower() == 'primary':
-        idents = [ident for ident, in split_pun_paren(group)]
+        idents = [ident for ident, in split_pun(next_instance(group, sqlparse.sql.Parenthesis))]
         # note: in theory we just want identifiers, but there are a lot of tokens and people use them by accident to name columns; most SQL engines accept it
         # (and this parser can't handle ticks I don't think)
         assert all(isinstance(ident, (sqlparse.sql.Identifier, sqlparse.sql.Token)) for ident in idents)
@@ -187,8 +192,8 @@ class CreateIndex(WrappedStatement):
 
   @property
   def index_name(self):
-    index_index = next(i for i, tok in enumerate(self.stmt) if tok.ttype and tok.ttype[-1] == 'Keyword' and tok.value == 'index')
-    on_index = next(i for i, tok in enumerate(self.stmt) if tok.ttype and tok.ttype[-1] == 'Keyword' and tok.value == 'on')
+    index_index = next(i for i, tok in enumerate(self.stmt) if tok.ttype and tok.ttype[-1] == 'Keyword' and tok.value.lower() == 'index')
+    on_index = next(i for i, tok in enumerate(self.stmt) if tok.ttype and tok.ttype[-1] == 'Keyword' and tok.value.lower() == 'on')
     block = self.stmt[index_index:on_index]
     ident, = next(tok for tok in block if isinstance(tok, sqlparse.sql.Identifier))
     return ident.value
@@ -202,7 +207,7 @@ class CreateIndex(WrappedStatement):
 def wrap(stmt):
   assert isinstance(stmt, sqlparse.sql.Statement)
   if stmt.get_type() == 'CREATE':
-    keywords = [tok.value for tok in stmt if tok.ttype and tok.ttype[-1] == 'Keyword']
+    keywords = [tok.value.lower() for tok in stmt if tok.ttype and tok.ttype[-1] == 'Keyword']
     if 'table' in keywords:
       return CreateTable(stmt)
     elif 'index' in keywords:

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -4,7 +4,7 @@ from automig.lib import diffing, wrappers
 RE_KEYWORDS = re.compile('create|table|int|primary key|alter|add|column|set|default|not null|type|varchar|unique|index|drop|constraint|on')
 
 def case_keywords(raw, casefn):
-  "helper for case manipulation. ugh"
+  "helper for case manipulation. ugh. this is necessary because 'alter table' stmts are always lowercase"
   found = RE_KEYWORDS.findall(raw)
   for keyword in found:
     raw = raw.replace(keyword, casefn(keyword))
@@ -50,7 +50,7 @@ ADD_COLUMN = [
 @pytest.mark.parametrize('tocase', [tolower, toupper])
 def test_add_column(tocase):
   delta = diffing.diff(*map(sqlparse.parse, tocase(ADD_COLUMN)))
-  assert delta == {'t1': ['alter table t1 add column b int;']}
+  assert delta == {'t1': [f'alter table t1 add column b {tocase("int")};']}
 
 ADD_COLUMN_PKEY = [
   'create table t1 (b int);',

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -1,6 +1,16 @@
 import pytest, sqlparse, collections
 from automig.lib import diffing, wrappers
 
+def tocase(value, case):
+  if isinstance(value, list):
+    return [tocase(val, case) for val in value]
+  if case == 'upper':
+    return value.upper()
+  elif case == 'lower':
+    return value.lower()
+  else:
+    raise ValueError('unk case', case)
+
 CREATE_TABLE = [
   'create table t1 (a int);',
   'create table t1 (a int); create table t2 (a int);',

--- a/test/test_diffing.py
+++ b/test/test_diffing.py
@@ -24,6 +24,10 @@ def toupper(vals):
     return {key: toupper(val) for key, val in vals.items()}
   return case_keywords(vals, str.upper)
 
+@pytest.fixture(params=[tolower, toupper])
+def tocase(request):
+  return request.param
+
 CREATE_TABLE = [
   'create table t1 (a int);',
   'create table t1 (a int); create table t2 (a int);',
@@ -32,7 +36,6 @@ CREATE_TABLE = [
 def test_case_keywords():
   assert case_keywords(CREATE_TABLE[0], str.upper) == 'CREATE TABLE t1 (a INT);'
 
-@pytest.mark.parametrize('tocase', [tolower, toupper])
 def test_create_table(tocase):
   delta = diffing.diff(*map(sqlparse.parse, tocase(CREATE_TABLE)))
   assert delta == tocase({'t2': ['create table t2 (a int);']})
@@ -47,7 +50,6 @@ ADD_COLUMN = [
   'create table t1 (a int primary key, b int);',
 ]
 
-@pytest.mark.parametrize('tocase', [tolower, toupper])
 def test_add_column(tocase):
   delta = diffing.diff(*map(sqlparse.parse, tocase(ADD_COLUMN)))
   assert delta == {'t1': [f'alter table t1 add column b {tocase("int")};']}
@@ -57,10 +59,10 @@ ADD_COLUMN_PKEY = [
   'create table t1 (a int primary key, b int);',
 ]
 
-def test_add_column_pkey():
+def test_add_column_pkey(tocase):
   "this is testing that this doesn't also do an 'alter table add primary key'"
-  assert diffing.diff(*map(sqlparse.parse, ADD_COLUMN_PKEY))['t1'] == \
-    ['alter table t1 add column a int primary key;']
+  assert diffing.diff(*map(sqlparse.parse, tocase(ADD_COLUMN_PKEY)))['t1'] == \
+    [f'alter table t1 add column a {tocase("int primary key")};']
 
 MODIFY_COLUMN = [
   'create table t1 (a jsonb primary key, b int default 10, c text[], d varchar(12));',
@@ -70,11 +72,11 @@ MODIFY_COLUMN = [
   'create table t1 (a jsonb primary key, b int default 20, c text[] not null, d varchar(24));',
 ]
 
-def test_modify_column():
-  assert diffing.diff(*map(sqlparse.parse, MODIFY_COLUMN)) == {'t1': [
+def test_modify_column(tocase):
+  assert diffing.diff(*map(sqlparse.parse, tocase(MODIFY_COLUMN))) == {'t1': [
     'alter table t1 alter column b set default 20;',
     'alter table t1 alter column c set not null;',
-    'alter table t1 alter column d type varchar(24);',
+    f'alter table t1 alter column d type {tocase("varchar")}(24);',
   ]}
 
 @pytest.mark.skip
@@ -100,7 +102,7 @@ def test_column_parser():
   # make sure it doesn't treat 'primary key' as a column
   assert [col.name for col in wrappers.wrap(sqlparse.parse("create table t1 (a int, b int, primary key (a,b))")[0]).columns()] == ['a', 'b']
 
-def test_pkey_fields():
+def test_pkey_fields(tocase):
   assert ['a'] == wrappers.wrap(sqlparse.parse("create table t1 (a int primary key, b int)")[0]).pkey_fields()
   assert ['a', 'b'] == wrappers.wrap(sqlparse.parse("create table t1 (a int, b int, primary key (a,b))")[0]).pkey_fields()
 
@@ -109,18 +111,18 @@ DROP_COLUMN = [
   'create table t1 (a int primary key, c int);',
 ]
 
-def test_drop_column():
-  delta = diffing.diff(*map(sqlparse.parse, DROP_COLUMN))
+def test_drop_column(tocase):
+  delta = diffing.diff(*map(sqlparse.parse, tocase(DROP_COLUMN)))
   assert delta == {'t1': ['alter table t1 drop column b;']}
 
-DROP_COLUMN__PKEY = [
+DROP_COLUMN_PKEY = [
   'create table t1 (a int primary key, b int);',
   'create table t1 (b int);',
 ]
 
-def test_drop_column_pkey():
+def test_drop_column_pkey(tocase):
   "this is testing that the 'drop constraint' comes before the 'drop column'"
-  assert diffing.diff(*map(sqlparse.parse, DROP_COLUMN__PKEY))['t1'] == \
+  assert diffing.diff(*map(sqlparse.parse, tocase(DROP_COLUMN_PKEY)))['t1'] == \
     ['alter table t1 drop constraint t1_pkey;', 'alter table t1 drop column a;']
 
 MODIFY_KEY_1 = [
@@ -138,11 +140,11 @@ MODIFY_KEY_3 = [
   'create table t1 (a int);',
 ]
 
-def test_modify_key():
-  assert not diffing.diff(*map(sqlparse.parse, MODIFY_KEY_1))
-  assert diffing.diff(*map(sqlparse.parse, MODIFY_KEY_2))['t1'] == [
+def test_modify_key(tocase):
+  assert not diffing.diff(*map(sqlparse.parse, tocase(MODIFY_KEY_1)))
+  assert diffing.diff(*map(sqlparse.parse, tocase(MODIFY_KEY_2)))['t1'] == [
     'alter table t1 drop constraint t1_pkey;',
-    'alter table t1 add column b int;',
+    f'alter table t1 add column b {tocase("int")};',
     'alter table t1 add primary key (a, b);',
   ]
   assert diffing.diff(*map(sqlparse.parse, MODIFY_KEY_3))['t1'] == ['alter table t1 drop constraint t1_pkey;']
@@ -153,17 +155,20 @@ CREATE_INDEX = [
   'create unique index idx_col1 on t1 (col1); create unique index idx_col2 on t1 (col2);',
 ]
 
-def test_add_index():
-  delta = diffing.diff(*map(sqlparse.parse, CREATE_INDEX))
-  assert delta == {'t1': ['create unique index idx_col2 on t1 (col2);']}
+def test_add_index(tocase):
+  delta = diffing.diff(*map(sqlparse.parse, tocase(CREATE_INDEX)))
+  assert delta == tocase({'t1': ['create unique index idx_col2 on t1 (col2);']})
 
 EDIT_INDEX = [
   'create index idx_col1 on t1 (col1);',
   'create index idx_col1 on t1 (col1, col2);',
 ]
 
-def test_edit_index():
-  assert diffing.diff(*map(sqlparse.parse, EDIT_INDEX))['t1'] == ['drop index idx_col1;', 'create index idx_col1 on t1 (col1, col2);']
+def test_edit_index(tocase):
+  assert diffing.diff(*map(sqlparse.parse, tocase(EDIT_INDEX)))['t1'] == [
+    'drop index idx_col1;',
+    tocase('create index idx_col1 on t1 (col1, col2);'),
+  ]
 
 @pytest.mark.skip
 def test_all_caps_keywords():
@@ -174,32 +179,32 @@ NEWLINE = [
   'create table whatever (\n  a int,\n  b int\n);',
 ]
 
-def test_newline():
+def test_newline(tocase):
   # this isn't asserting anything -- checking for a bug which caused a crash
-  diffing.diff(*map(sqlparse.parse, NEWLINE))
+  diffing.diff(*map(sqlparse.parse, tocase(NEWLINE)))
 
 COMMENT = [
   'create table whatever (\n  a int -- hello\n);',
   'create table whatever (\n  a int, -- hello\n  b int\n);',
 ]
 
-def test_comments():
+def test_comments(tocase):
   # not asserting, just checking for crash
-  diffing.diff(*map(sqlparse.parse, COMMENT))
+  diffing.diff(*map(sqlparse.parse, tocase(COMMENT)))
 
 PARTITION = [
   'create table whatever (a boolean primary key);',
   'create table whatever (a boolean primary key) partition by range (a);',
 ]
 
-def test_tail():
+def test_tail(tocase):
   "directly test CreateTable.tail()"
-  no, yes = [wrappers.wrap(parsed[0]) for parsed in map(sqlparse.parse, PARTITION)]
+  no, yes = [wrappers.wrap(parsed[0]) for parsed in map(sqlparse.parse, tocase(PARTITION))]
   assert no.tail() == []
   assert ['partition', 'by', 'range (a)'] == [tok.value for tok in yes.tail()]
 
-def test_partition():
-  assert diffing.diff(*map(sqlparse.parse, PARTITION))['whatever'][0].args == \
+def test_partition(tocase):
+  assert diffing.diff(*map(sqlparse.parse, tocase(PARTITION)))['whatever'][0].args == \
     ("can't modify table suffix: `partition by range (a)`",)
 
 UNIQUE = [
@@ -207,6 +212,6 @@ UNIQUE = [
   'create table whatever (a text);',
 ]
 
-def test_modify_unique():
-  assert diffing.diff(*map(sqlparse.parse, UNIQUE))['whatever'] == ['alter table whatever drop constraint whatever_a_key;']
-  assert diffing.diff(*map(sqlparse.parse, reversed(UNIQUE)))['whatever'][0].args == ("can't add unique constraint, file a bug",)
+def test_modify_unique(tocase):
+  assert diffing.diff(*map(sqlparse.parse, tocase(UNIQUE)))['whatever'] == ['alter table whatever drop constraint whatever_a_key;']
+  assert diffing.diff(*map(sqlparse.parse, tocase(reversed(UNIQUE))))['whatever'][0].args == ("can't add unique constraint, file a bug",)


### PR DESCRIPTION
* add `tocase` fixture to test upper & lowercase inputs
* fixes to `split_pun_paren` and `decl` to deal with sqlparse differences between upper & lowercase